### PR TITLE
git-auto-commit-actionが発動した場合にGHAが実行されない問題の対応

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       - uses: oven-sh/setup-bun@v1
       - run: bun install


### PR DESCRIPTION
https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs