### PR TITLE
マイマップでオーナーの名前が表示されないようにする

### DIFF
--- a/k6/maps.html
+++ b/k6/maps.html
@@ -8,6 +8,6 @@
 
 <body>
     <h1>不妊治療を行う医療機関マップ</h1>
-    <iframe src="https://www.google.com/maps/d/embed?mid=1gd2greo6MBNbdGLsUc1yopBY3zpkwiQ&hl=ja&ehbc=2E312F" width="640" height="480"></iframe>
+    <iframe src="https://www.google.com/maps/d/embed?mid=1gd2greo6MBNbdGLsUc1yopBY3zpkwiQ&ehbc=2E312F&noprof=1" width="640" height="480"></iframe>
 </body>
 </html>


### PR DESCRIPTION
- #92 のmerge後マイマップのオーナーの名前とプロフィール画像が表示されることに気付いたので修正